### PR TITLE
Add table component

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import React from "react";
+import { Table } from "./Table";
+
+export default {
+  title: "Components/Table",
+  component: Table,
+  argTypes: {
+    variant: {
+      control: { type: "select" },
+      options: ["default", "withActions"],
+      description: "Choose table variant for static or interactive behavior",
+      defaultValue: "default",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A flexible table component that supports both read-only and interactive data display. Use `variant` to toggle action columns.",
+      },
+    },
+  },
+};
+
+const data = [
+  {
+    name: "Usuario Prueba",
+    email: "Prueba@gmail.com",
+    password: "Prueba123",
+    role: "Data Manager",
+  },
+  {
+    name: "Marcela",
+    email: "Marcela@gmail.com",
+    password: "Marcela123",
+    role: "Data Visualizer",
+  },
+  {
+    name: "Jose",
+    email: "Jose@gmail.com",
+    password: "Jose123",
+    role: "Administrador",
+  },
+  {
+    name: "Mariana",
+    email: "Mariana@gmail.com",
+    password: "Mariana123",
+    role: "Data Visualizer",
+  },
+  {
+    name: "Alondra",
+    email: "Alondra@gmail.com",
+    password: "Alondra123",
+    role: "Data Manager",
+  },
+  {
+    name: "Diego",
+    email: "Diego@gmail.com",
+    password: "Diego123",
+    role: "Data Visualizer",
+  },
+  {
+    name: "Brayan",
+    email: "Brayan@gmail.com",
+    password: "Brayan123",
+    role: "Administrador",
+  },
+  {
+    name: "Montserrat",
+    email: "Montserrat@gmail.com",
+    password: "Montserrat123",
+    role: "Administrador",
+  },
+  {
+    name: "Ricardo",
+    email: "Ricardo@gmail.com",
+    password: "Ricardo123",
+    role: "Data Visualizer",
+  },
+];
+
+const actions = [
+  {
+    label: "Modificar",
+    onClick: (row: any) => alert(`Modificar: ${row.name}`),
+  },
+  {
+    label: "Eliminar",
+    onClick: (row: any) => alert(`Eliminar: ${row.name}`),
+    className: "text-red-500",
+  },
+];
+
+export const Default = () => (
+  <Table
+    variant="default"
+    columns={[
+      { header: "Usuario", accessor: "name" },
+      { header: "Correo electrónico", accessor: "email" },
+      { header: "Contraseña", accessor: "password" },
+      { header: "Rol", accessor: "role" },
+    ]}
+    data={data}
+  />
+);
+
+export const WithActions = () => (
+  <Table
+    variant="withActions"
+    columns={[
+      { header: "Usuario", accessor: "name" },
+      { header: "Correo electrónico", accessor: "email" },
+      { header: "Contraseña", accessor: "password" },
+      { header: "Rol", accessor: "role" },
+    ]}
+    data={data}
+    actions={actions}
+  />
+);

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import {
+  Table as BaseTable,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+type TableVariant = "default" | "withActions";
+
+type Column<T> = {
+  header: string;
+  accessor: keyof T;
+};
+
+type Action<T> = {
+  label: string;
+  onClick: (row: T) => void;
+  className?: string;
+};
+
+type TableProps<T> = {
+  variant?: TableVariant;
+  columns: Column<T>[];
+  data: T[];
+  actions?: Action<T>[];
+};
+
+export function Table<T extends Record<string, any>>({
+  variant = "default",
+  columns,
+  data,
+  actions = [],
+}: TableProps<T>) {
+  return (
+    <div className="w-full overflow-x-auto border rounded">
+      <BaseTable>
+        <TableHeader>
+          <TableRow>
+            {columns.map((col) => (
+              <TableHead key={String(col.accessor)}>{col.header}</TableHead>
+            ))}
+            {variant === "withActions" && <TableHead>Acción</TableHead>}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((row, rowIndex) => (
+            <TableRow key={rowIndex}>
+              {columns.map((col) => (
+                <TableCell key={String(col.accessor)}>
+                  {row[col.accessor]}
+                </TableCell>
+              ))}
+              {variant === "withActions" && (
+                <TableCell>
+                  <div className="flex gap-2">
+                    {actions.map((action, actionIndex) => (
+                      <button
+                        key={actionIndex}
+                        onClick={() => action.onClick(row)}
+                        className={`text-sm underline ${action.className}`}
+                      >
+                        {action.label}
+                      </button>
+                    ))}
+                  </div>
+                </TableCell>
+              )}
+            </TableRow>
+          ))}
+        </TableBody>
+      </BaseTable>
+    </div>
+  );
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
This PR introduces a new Table component designed to support both read-only and interactive data display. The component is built on top of shadcn's base table styles and includes support for a variant prop that toggles between modes.

Component will be used for displaying these Figma components: 

_Default Table_
<img width="564" alt="Screenshot 2025-04-24 at 5 01 36 p m" src="https://github.com/user-attachments/assets/438afdbd-8cdf-45b3-babc-e754b672dcfd" />

_Actions Table_
<img width="508" alt="Screenshot 2025-04-24 at 5 02 22 p m" src="https://github.com/user-attachments/assets/e32fdbd9-e009-494f-9f32-8f303a510789" />
